### PR TITLE
Fix: Apply Prettier formatting to declaration files

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -16,9 +16,7 @@ infrastructure/.cdk.staging/
 
 # Compiled files
 *.js
-*.d.ts
 infrastructure/*.js
-infrastructure/*.d.ts
 
 # Keep source files
 !infrastructure/**/*.ts

--- a/infrastructure/lib/constructs/api-construct.d.ts
+++ b/infrastructure/lib/constructs/api-construct.d.ts
@@ -4,18 +4,18 @@ import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 export interface ApiConstructProps {
-    environment: 'dev' | 'prod';
-    userTable: dynamodb.Table;
-    natalChartTable: dynamodb.Table;
-    userPool: cognito.UserPool;
-    placeIndexName: string;
-    allowedOrigins: string[];
+  environment: 'dev' | 'prod';
+  userTable: dynamodb.Table;
+  natalChartTable: dynamodb.Table;
+  userPool: cognito.UserPool;
+  placeIndexName: string;
+  allowedOrigins: string[];
 }
 export declare class ApiConstruct extends Construct {
-    readonly api: apigateway.RestApi;
-    readonly getUserProfileFunction: lambda.Function;
-    readonly updateUserProfileFunction: lambda.Function;
-    readonly generateNatalChartFunction: lambda.Function;
-    readonly getNatalChartFunction: lambda.Function;
-    constructor(scope: Construct, id: string, props: ApiConstructProps);
+  readonly api: apigateway.RestApi;
+  readonly getUserProfileFunction: lambda.Function;
+  readonly updateUserProfileFunction: lambda.Function;
+  readonly generateNatalChartFunction: lambda.Function;
+  readonly getNatalChartFunction: lambda.Function;
+  constructor(scope: Construct, id: string, props: ApiConstructProps);
 }

--- a/infrastructure/lib/constructs/cognito-auth-construct.d.ts
+++ b/infrastructure/lib/constructs/cognito-auth-construct.d.ts
@@ -1,14 +1,14 @@
 import { Construct } from 'constructs';
 import * as cognito from 'aws-cdk-lib/aws-cognito';
 export interface CognitoAuthConstructProps {
-    environment: 'dev' | 'prod';
-    domainPrefix: string;
-    callbackUrls: string[];
-    logoutUrls: string[];
+  environment: 'dev' | 'prod';
+  domainPrefix: string;
+  callbackUrls: string[];
+  logoutUrls: string[];
 }
 export declare class CognitoAuthConstruct extends Construct {
-    readonly userPool: cognito.UserPool;
-    readonly userPoolClient: cognito.UserPoolClient;
-    readonly userPoolDomain: cognito.UserPoolDomain;
-    constructor(scope: Construct, id: string, props: CognitoAuthConstructProps);
+  readonly userPool: cognito.UserPool;
+  readonly userPoolClient: cognito.UserPoolClient;
+  readonly userPoolDomain: cognito.UserPoolDomain;
+  constructor(scope: Construct, id: string, props: CognitoAuthConstructProps);
 }

--- a/infrastructure/lib/website-stack.d.ts
+++ b/infrastructure/lib/website-stack.d.ts
@@ -6,16 +6,16 @@ import { Construct } from 'constructs';
 import { CognitoAuthConstruct } from './constructs/cognito-auth-construct';
 import { ApiConstruct } from './constructs/api-construct';
 export interface WebsiteStackProps extends cdk.StackProps {
-    domainName: string;
-    subdomain?: string;
-    certificateArn?: string;
-    environment: 'dev' | 'prod';
+  domainName: string;
+  subdomain?: string;
+  certificateArn?: string;
+  environment: 'dev' | 'prod';
 }
 export declare class WebsiteStack extends cdk.Stack {
-    readonly distribution: cloudfront.Distribution;
-    readonly bucket: s3.Bucket;
-    readonly auth: CognitoAuthConstruct;
-    readonly userTable: dynamodb.Table;
-    readonly api: ApiConstruct;
-    constructor(scope: Construct, id: string, props: WebsiteStackProps);
+  readonly distribution: cloudfront.Distribution;
+  readonly bucket: s3.Bucket;
+  readonly auth: CognitoAuthConstruct;
+  readonly userTable: dynamodb.Table;
+  readonly api: ApiConstruct;
+  constructor(scope: Construct, id: string, props: WebsiteStackProps);
 }


### PR DESCRIPTION
This commit fixes the formatting of the TypeScript declaration (.d.ts) files that were causing the 'format:check' step to fail in the CI pipeline.

The `.prettierignore` file was updated to remove the rules that excluded `.d.ts` files from formatting. The Prettier format command was then run to apply the correct code styles to these files.