### PR TITLE
fix: Update OpenAI API to use max_completion_tokens parameter

### DIFF
--- a/infrastructure/lambda/readings/generate-reading.ts
+++ b/infrastructure/lambda/readings/generate-reading.ts
@@ -244,7 +244,7 @@ async function callOpenAI(prompt: string, config: OpenAIConfig): Promise<string>
         },
       ],
       temperature: config.temperature,
-      max_tokens: config.maxTokens,
+      max_completion_tokens: config.maxTokens,
     }),
   });
 


### PR DESCRIPTION
- Changed max_tokens to max_completion_tokens to support newer OpenAI models (gpt-5)
- Fixes 500 error when generating readings