### PR TITLE
fix: Resolve Admin Page focus trap conflict between dropdown and modals

### DIFF
--- a/frontend/app/admin/page.tsx
+++ b/frontend/app/admin/page.tsx
@@ -49,12 +49,12 @@ export default function AdminDashboard() {
 
   const handleViewDetails = useCallback((userId: string, readingId: string) => {
     setSelectedReading({ userId, readingId });
-    setDetailsSheetOpen(true);
+    setTimeout(() => setDetailsSheetOpen(true), 0);
   }, []);
 
   const handleDeleteClick = useCallback((userId: string, readingId: string, userEmail?: string) => {
     setReadingToDelete({ userId, id: readingId, email: userEmail });
-    setDeleteDialogOpen(true);
+    setTimeout(() => setDeleteDialogOpen(true), 0);
   }, []);
 
   const handleDeleteConfirm = useCallback(


### PR DESCRIPTION
Applied Gemini's solution: Use setTimeout(0) to decouple modal opening from dropdown menu closure. This allows the DropdownMenu to fully clean up its focus management before Sheet/AlertDialog take control.

Problem: Radix UI DropdownMenu and Sheet/AlertDialog were conflicting over focus control, causing page to become unresponsive after first use.

Solution: Delay modal opening to next event loop tick, ensuring clean handoff of focus management between components.

🤖 Generated with Claude Code